### PR TITLE
Minor cleanup for top level CMakeLists.txt file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,15 +11,6 @@ set(TBB_TEST OFF CACHE BOOL " " FORCE)
 set(TBB_EXAMPLES OFF CACHE BOOL " " FORCE)
 add_subdirectory(arrangements/external/oneTBB)
 
-# add the executable
-add_executable(${PROJECT_NAME} main.cpp)
-
-target_include_directories(${PROJECT_NAME} PUBLIC
-    ./
-    code/
-    arrangements/code/
-)
-
 set(cinolib_DIR ${PROJECT_SOURCE_DIR}/arrangements/external/Cinolib)
 set(CINOLIB_USES_OPENGL_GLFW_IMGUI ON)
 set(CINOLIB_USES_SHEWCHUK_PREDICATES ON)
@@ -27,51 +18,34 @@ set(CINOLIB_USES_INDIRECT_PREDICATES ON)
 
 find_package(cinolib REQUIRED)
 
-target_link_libraries(${PROJECT_NAME} cinolib)
-target_link_libraries(${PROJECT_NAME} tbb)
-target_compile_definitions(${PROJECT_NAME} PUBLIC TBB_PARALLEL=1)
-target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/arrangements/external/abseil-cpp/)
-target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/arrangements/external/oneTBB/)
+set(IRMB_INCLUDE_DIRS
+	${PROJECT_SOURCE_DIR}
+	${PROJECT_SOURCE_DIR}/code
+	${PROJECT_SOURCE_DIR}/arrangements/code
+	${PROJECT_SOURCE_DIR}/arrangements/external/abseil-cpp
+	${PROJECT_SOURCE_DIR}/arrangements/external/oneTBB
+	)
 
+set(IRMB_LIBS cinolib tbb)
+
+# add the executable
+add_executable(${PROJECT_NAME} main.cpp)
+target_include_directories(${PROJECT_NAME} PUBLIC ${IRMB_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME} ${IRMB_LIBS})
+target_compile_definitions(${PROJECT_NAME} PUBLIC TBB_PARALLEL=1)
 
 add_executable(${PROJECT_NAME}_rotation main-rotation.cpp)
-
-target_include_directories(${PROJECT_NAME}_rotation PUBLIC
-    ./
-    code/
-    arrangements/code/
-)
-
-target_link_libraries(${PROJECT_NAME}_rotation cinolib)
-target_link_libraries(${PROJECT_NAME}_rotation tbb)
+target_include_directories(${PROJECT_NAME}_rotation PUBLIC ${IRMB_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME}_rotation ${IRMB_LIBS})
 target_compile_definitions(${PROJECT_NAME}_rotation PUBLIC TBB_PARALLEL=1)
-target_include_directories(${PROJECT_NAME}_rotation PUBLIC ${PROJECT_SOURCE_DIR}/arrangements/external/abseil-cpp/)
-target_include_directories(${PROJECT_NAME}_rotation PUBLIC ${PROJECT_SOURCE_DIR}/arrangements/external/oneTBB/)
 
 add_executable(${PROJECT_NAME}_arap main-arap.cpp)
-
-target_include_directories(${PROJECT_NAME}_arap PUBLIC
-    ./
-    code/
-    arrangements/code/
-)
-
-target_link_libraries(${PROJECT_NAME}_arap cinolib)
-target_link_libraries(${PROJECT_NAME}_arap tbb)
+target_include_directories(${PROJECT_NAME}_arap PUBLIC ${IRMB_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME}_arap ${IRMB_LIBS})
 target_compile_definitions(${PROJECT_NAME}_arap PUBLIC TBB_PARALLEL=1)
-target_include_directories(${PROJECT_NAME}_arap PUBLIC ${PROJECT_SOURCE_DIR}/arrangements/external/abseil-cpp/)
-target_include_directories(${PROJECT_NAME}_arap PUBLIC ${PROJECT_SOURCE_DIR}/arrangements/external/oneTBB/)
 
 add_executable(${PROJECT_NAME}_stencil main-stencil.cpp)
-
-target_include_directories(${PROJECT_NAME}_stencil PUBLIC
-    ./
-    code/
-    arrangements/code/
-)
-
-target_link_libraries(${PROJECT_NAME}_stencil cinolib)
-target_link_libraries(${PROJECT_NAME}_stencil tbb)
+target_include_directories(${PROJECT_NAME}_stencil PUBLIC ${IRMB_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME}_stencil ${IRMB_LIBS})
 target_compile_definitions(${PROJECT_NAME}_stencil PUBLIC TBB_PARALLEL=1)
-target_include_directories(${PROJECT_NAME}_stencil PUBLIC ${PROJECT_SOURCE_DIR}/arrangements/external/abseil-cpp/)
-target_include_directories(${PROJECT_NAME}_stencil PUBLIC ${PROJECT_SOURCE_DIR}/arrangements/external/oneTBB/)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,12 +19,12 @@ set(CINOLIB_USES_INDIRECT_PREDICATES ON)
 find_package(cinolib REQUIRED)
 
 set(IRMB_INCLUDE_DIRS
-	${PROJECT_SOURCE_DIR}
-	${PROJECT_SOURCE_DIR}/code
-	${PROJECT_SOURCE_DIR}/arrangements/code
-	${PROJECT_SOURCE_DIR}/arrangements/external/abseil-cpp
-	${PROJECT_SOURCE_DIR}/arrangements/external/oneTBB
-	)
+  ${PROJECT_SOURCE_DIR}
+  ${PROJECT_SOURCE_DIR}/code
+  ${PROJECT_SOURCE_DIR}/arrangements/code
+  ${PROJECT_SOURCE_DIR}/arrangements/external/abseil-cpp
+  ${PROJECT_SOURCE_DIR}/arrangements/external/oneTBB
+  )
 
 set(IRMB_LIBS cinolib tbb)
 
@@ -48,4 +48,12 @@ add_executable(${PROJECT_NAME}_stencil main-stencil.cpp)
 target_include_directories(${PROJECT_NAME}_stencil PUBLIC ${IRMB_INCLUDE_DIRS})
 target_link_libraries(${PROJECT_NAME}_stencil ${IRMB_LIBS})
 target_compile_definitions(${PROJECT_NAME}_stencil PUBLIC TBB_PARALLEL=1)
+
+
+# Local Variables:
+# tab-width: 8
+# mode: cmake
+# indent-tabs-mode: t
+# End:
+# ex: shiftwidth=2 tabstop=8
 


### PR DESCRIPTION
Since the top level targets need a lot of the same info, we can consolidate that duplication into a couple variables.