### PR TITLE
Fix(build): Resolve compilation errors on Visual Studio 2022

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,137 +1,105 @@
 cmake_minimum_required(VERSION 3.21)
 
-# Set the target architecture.
-# All modern x86/x64 processors support AVX2.
-# Older x86/x64 processors may support SSE2 but not AVX2.
-# Very old x86/x64 processors, or non x86/x64
-# processors, do not support any of the two.
-set(ENABLE_SSE2 True)
-set(ENABLE_AVX2 True)
+# set the project name
+project(mesh_booleans)
 
-
+# --- Project-wide Settings ---
 # specify the C++ standard
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
-# set the project name
-project(mesh_booleans)
+# Set the target architecture flags.
+set(ENABLE_SSE2 True)
+set(ENABLE_AVX2 True)
 
-set(TBB_TEST OFF CACHE BOOL " " FORCE)
-set(TBB_EXAMPLES OFF CACHE BOOL " " FORCE)
+
+# --- Dependency: oneTBB ---
+# Correctly build oneTBB as a subdirectory
+set(TBB_TEST OFF CACHE BOOL "Disable TBB tests" FORCE)
+set(TBB_EXAMPLES OFF CACHE BOOL "Disable TBB examples" FORCE)
 add_subdirectory(arrangements/external/oneTBB)
 
 
-# add the executable
-add_executable(${PROJECT_NAME} main.cpp)
+# --- Dependency: Abseil ---
+# CORRECT WAY TO ADD ABSEIL: Build it as a subdirectory.
+# CMake will configure it, build its libraries, and create targets for us to link against.
+add_subdirectory(arrangements/external/abseil-cpp)
 
-target_include_directories(${PROJECT_NAME} PUBLIC
-    ./
-    code/
-    arrangements/code/
-    arrangements/external/Indirect_Predicates/include/
-)
 
+# --- Dependency: Cinolib ---
+# Your Cinolib configuration looks good.
 set(cinolib_DIR ${PROJECT_SOURCE_DIR}/arrangements/external/Cinolib)
 set(CINOLIB_USES_OPENGL_GLFW_IMGUI ON)
 set(CINOLIB_USES_SHEWCHUK_PREDICATES ON)
-
 find_package(cinolib REQUIRED)
 
-target_link_libraries(${PROJECT_NAME} cinolib)
-target_link_libraries(${PROJECT_NAME} tbb)
-target_compile_definitions(${PROJECT_NAME} PUBLIC TBB_PARALLEL=1)
-target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/arrangements/external/abseil-cpp/)
-target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/arrangements/external/oneTBB/)
 
-
-add_executable(${PROJECT_NAME}_rotation main-rotation.cpp)
-
-target_include_directories(${PROJECT_NAME}_rotation PUBLIC
-    ./
-    code/
-    arrangements/code/
-    arrangements/external/Indirect_Predicates/include/
+# --- Define all your executables ---
+# We list all targets here to avoid repetition later.
+set(ALL_TARGETS
+    ${PROJECT_NAME}
+    ${PROJECT_NAME}_rotation
+    ${PROJECT_NAME}_arap
+    ${PROJECT_NAME}_stencil
+    ${PROJECT_NAME}_inputcheck
 )
 
-target_link_libraries(${PROJECT_NAME}_rotation cinolib)
-target_link_libraries(${PROJECT_NAME}_rotation tbb)
-target_compile_definitions(${PROJECT_NAME}_rotation PUBLIC TBB_PARALLEL=1)
-target_include_directories(${PROJECT_NAME}_rotation PUBLIC ${PROJECT_SOURCE_DIR}/arrangements/external/abseil-cpp/)
-target_include_directories(${PROJECT_NAME}_rotation PUBLIC ${PROJECT_SOURCE_DIR}/arrangements/external/oneTBB/)
-
-add_executable(${PROJECT_NAME}_arap main-arap.cpp)
-
-target_include_directories(${PROJECT_NAME}_arap PUBLIC
-    ./
-    code/
-    arrangements/code/
-    arrangements/external/Indirect_Predicates/include/
-)
-
-target_link_libraries(${PROJECT_NAME}_arap cinolib)
-target_link_libraries(${PROJECT_NAME}_arap tbb)
-target_compile_definitions(${PROJECT_NAME}_arap PUBLIC TBB_PARALLEL=1)
-target_include_directories(${PROJECT_NAME}_arap PUBLIC ${PROJECT_SOURCE_DIR}/arrangements/external/abseil-cpp/)
-target_include_directories(${PROJECT_NAME}_arap PUBLIC ${PROJECT_SOURCE_DIR}/arrangements/external/oneTBB/)
-
-add_executable(${PROJECT_NAME}_stencil main-stencil.cpp)
-
-target_include_directories(${PROJECT_NAME}_stencil PUBLIC
-    ./
-    code/
-    arrangements/code/
-    arrangements/external/Indirect_Predicates/include/
-)
-
-target_link_libraries(${PROJECT_NAME}_stencil cinolib)
-target_link_libraries(${PROJECT_NAME}_stencil tbb)
-target_compile_definitions(${PROJECT_NAME}_stencil PUBLIC TBB_PARALLEL=1)
-target_include_directories(${PROJECT_NAME}_stencil PUBLIC ${PROJECT_SOURCE_DIR}/arrangements/external/abseil-cpp/)
-target_include_directories(${PROJECT_NAME}_stencil PUBLIC ${PROJECT_SOURCE_DIR}/arrangements/external/oneTBB/)
-
-
+add_executable(${PROJECT_NAME}           main.cpp)
+add_executable(${PROJECT_NAME}_rotation  main-rotation.cpp)
+add_executable(${PROJECT_NAME}_arap      main-arap.cpp)
+add_executable(${PROJECT_NAME}_stencil   main-stencil.cpp)
 add_executable(${PROJECT_NAME}_inputcheck main-inputcheck.cpp)
 
-target_include_directories(${PROJECT_NAME}_inputcheck PUBLIC
+
+# --- Configure ALL targets in a loop to avoid repetition and bugs ---
+foreach(TARGET ${ALL_TARGETS})
+    # --- Include Directories ---
+    # These are common to all targets.
+    target_include_directories(${TARGET} PUBLIC
         ./
         code/
         arrangements/code/
         arrangements/external/Indirect_Predicates/include/
-)
+    )
 
-target_link_libraries(${PROJECT_NAME}_inputcheck cinolib)
-target_link_libraries(${PROJECT_NAME}_inputcheck tbb)
-target_compile_definitions(${PROJECT_NAME}_inputcheck PUBLIC TBB_PARALLEL=1)
-target_include_directories(${PROJECT_NAME}_inputcheck PUBLIC ${PROJECT_SOURCE_DIR}/arrangements/external/abseil-cpp/)
-target_include_directories(${PROJECT_NAME}_inputcheck PUBLIC ${PROJECT_SOURCE_DIR}/arrangements/external/oneTBB/)
+    # --- Link Libraries ---
+    # Link against the libraries created by our dependencies.
+    # Note how we link to specific absl::* targets now.
+    target_link_libraries(${TARGET} PUBLIC
+        cinolib
+        tbb
+        absl::time          # For absl::CivilTime and related functions
+        absl::base          # Often a required base library
+        absl::strings       # Useful for string manipulations
+        # Add other absl::* targets if needed, e.g., absl::container
+    )
 
-# Compiler-specific options
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-        # grant IEEE 754 compliance
-        target_compile_options(${PROJECT_NAME} PUBLIC "/fp:strict")
-        # use intrinsic functions
-        target_compile_options(${PROJECT_NAME} PUBLIC "/Oi")
-        # set target architecture
+    # --- Compile Definitions ---
+    # These definitions are applied to all targets.
+    target_compile_definitions(${TARGET} PUBLIC
+        TBB_PARALLEL=1
+        # [FIX] Add NOMINMAX to prevent conflicts with windows.h macros (min/max)
+        $<$<PLATFORM_ID:Windows>:NOMINMAX>
+        $<$<CXX_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS>
+    )
+
+    # --- Compiler-specific Options ---
+    # This block now correctly applies to EACH target in the loop.
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        target_compile_options(${TARGET} PUBLIC "/fp:strict" "/Oi")
         if(ENABLE_AVX2)
-                target_compile_options(${PROJECT_NAME} PUBLIC "/arch:AVX2")
+            target_compile_options(${TARGET} PUBLIC "/arch:AVX2")
         elseif(ENABLE_SSE2)
-                target_compile_options(${PROJECT_NAME} PUBLIC "/arch:SSE2")
+            target_compile_options(${TARGET} PUBLIC "/arch:SSE2")
         endif()
-        # reserve enough stack size
-        target_link_options(${PROJECT_NAME} PUBLIC "/STACK:8421376")
-        # turn off annoying warnings
-        target_compile_options(${PROJECT_NAME} PUBLIC "/D _CRT_SECURE_NO_WARNINGS")
-else()
-        # set standard optimization level
-        target_compile_options(${PROJECT_NAME} PUBLIC -O2)
-        # reserve enough stack size
-        target_compile_options(${PROJECT_NAME} PUBLIC -Wl,-z,stacksize=8421376)
-        # grant IEEE 754 compliance
-        target_compile_options(${PROJECT_NAME} PUBLIC -frounding-math)
-        # set target architecture
+        target_link_options(${TARGET} PUBLIC "/STACK:8421376")
+    else() # For GCC/Clang
+        target_compile_options(${TARGET} PUBLIC -O2 -frounding-math)
+        target_link_options(${TARGET} PUBLIC -Wl,-z,stack-size=8421376)
         if(ENABLE_AVX2)
-                target_compile_options(${PROJECT_NAME} PUBLIC "-mavx2")
+            target_compile_options(${TARGET} PUBLIC "-mavx2")
         elseif(ENABLE_SSE2)
-                target_compile_options(${PROJECT_NAME} PUBLIC "-msse2")
+            target_compile_options(${TARGET} PUBLIC "-msse2")
         endif()
-endif()
+    endif()
+endforeach()


### PR DESCRIPTION
更新 CMakeLists.txt 以解决在 VS2022 环境下的构建失败问题。

主要改动包括：
- 使用 `add_subdirectory` 正确集成 Abseil 库。
- 添加 `NOMINMAX` 宏定义以防止与 Windows SDK 的宏冲突。
- 重构了目标配置，以确保所有可执行文件都应用了相同的编译和链接选项。